### PR TITLE
Fix auto chat titles by using the selected model

### DIFF
--- a/ui/src/main/java/com/beradeep/aiyo/ui/screens/chat/ChatViewModel.kt
+++ b/ui/src/main/java/com/beradeep/aiyo/ui/screens/chat/ChatViewModel.kt
@@ -251,7 +251,7 @@ open class ChatViewModel(
             val summaryTitle =
                 chatRepository.getChatCompletion(
                     apiKey = uiState.value.apiKey,
-                    model = Model("mistralai/mistral-nemo:free"),
+                    model = uiState.value.selectedModel,
                     messages = messages.map(UiMessage::toMessage) + prompt
                 )
             summaryTitle


### PR DESCRIPTION
## What

Automatic conversation titling has been silently broken: `aiUpdateConversationTitle()` is hardcoded to call `mistralai/mistral-nemo:free`, which no longer exists on OpenRouter, so every title request fails and conversations keep their `Untitled: <date>` placeholder.

This one-line fix uses the conversation's currently selected model for the title request instead. That model is guaranteed to be valid for the user's key (they're actively chatting with it), and the fix can't rot the way a hardcoded model id does.

## Testing

- `:app:compileDebugKotlin` and `testDebugUnitTest` pass.
- Manually tested on a physical device — new conversations now get titled after the first exchange:

<img src="https://raw.githubusercontent.com/GSmithBoltz/aiyo/pr-assets/screenshots/auto_title.jpg" width="340" alt="Conversation drawer showing an auto-generated title alongside older Untitled conversations from before the fix" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)